### PR TITLE
Fix Plaintext Data Access Overflow in psi.onnx.c Execution

### DIFF
--- a/fhe-cmplr/ckks/src/dfg_region_builder.cxx
+++ b/fhe-cmplr/ckks/src/dfg_region_builder.cxx
@@ -410,17 +410,6 @@ void REGION_BUILDER::Opt_mul_depth() {
       Unify_mul_depth(scc_list);
     }
   }
-
-  // 3, traversal all scc node to 
-  //   place input cipher(have no predecessor) at region 1
-  for (SCC_CONTAINER::NODE_ITER scc_iter = scc_cntr->Begin_node();
-      scc_iter != scc_cntr->End_node(); ++scc_iter) {
-    uint32_t mul_depth = Mul_depth(scc_iter->Id());
-    if (mul_depth == INVALID_MUL_DEPTH) continue;
-    if (scc_iter->Begin_pred() == scc_iter->End_pred()){
-      Set_mul_depth(scc_iter->Id(), 1);
-    }
-  }
 }
 
 //! @brief Create regions. REGION_ELEMs with the same mul_depth are grouped

--- a/fhe-cmplr/ckks/src/dfg_region_builder.cxx
+++ b/fhe-cmplr/ckks/src/dfg_region_builder.cxx
@@ -410,6 +410,17 @@ void REGION_BUILDER::Opt_mul_depth() {
       Unify_mul_depth(scc_list);
     }
   }
+
+  // 3, traversal all scc node to 
+  //   place input cipher(have no predecessor) at region 1
+  for (SCC_CONTAINER::NODE_ITER scc_iter = scc_cntr->Begin_node();
+      scc_iter != scc_cntr->End_node(); ++scc_iter) {
+    uint32_t mul_depth = Mul_depth(scc_iter->Id());
+    if (mul_depth == INVALID_MUL_DEPTH) continue;
+    if (scc_iter->Begin_pred() == scc_iter->End_pred()){
+      Set_mul_depth(scc_iter->Id(), 1);
+    }
+  }
 }
 
 //! @brief Create regions. REGION_ELEMs with the same mul_depth are grouped

--- a/fhe-cmplr/rtlib/ant/ckks/src/cipher.c
+++ b/fhe-cmplr/rtlib/ant/ckks/src/cipher.c
@@ -56,13 +56,15 @@ void Init_ciph_same_scale(CIPHER res, CIPHER ciph1, CIPHER ciph2) {
 
 void Init_ciph_same_scale_plain(CIPHER res, CIPHER ciph, PLAIN plain) {
   RTLIB_TM_START(RTM_INIT_CIPH_SM_SC, rtm);
-  if(Poly_level(&plain->_poly) < Get_ciph_level(ciph)){
+  if(Poly_level(Get_plain_poly(plain)) < Get_ciph_level(ciph)){
     CIPHER ciph_tmp = Alloc_ciphertext();
     Copy_ciph(ciph_tmp, ciph);
-    Set_ciph_level(ciph_tmp, Poly_level(&plain->_poly));
+    Set_ciph_level(ciph_tmp, Poly_level(Get_plain_poly(plain)));
     Init_cipher(res, ciph_tmp, Get_ciph_sfactor(ciph_tmp), Sc_degree(ciph_tmp));
   }
-  else Init_cipher(res, ciph, Get_ciph_sfactor(ciph), Sc_degree(ciph));
+  else{
+    Init_cipher(res, ciph, Get_ciph_sfactor(ciph), Sc_degree(ciph));
+  }
   RTLIB_TM_END(RTM_INIT_CIPH_SM_SC, rtm);
 }
 

--- a/fhe-cmplr/rtlib/ant/ckks/src/cipher.c
+++ b/fhe-cmplr/rtlib/ant/ckks/src/cipher.c
@@ -56,7 +56,13 @@ void Init_ciph_same_scale(CIPHER res, CIPHER ciph1, CIPHER ciph2) {
 
 void Init_ciph_same_scale_plain(CIPHER res, CIPHER ciph, PLAIN plain) {
   RTLIB_TM_START(RTM_INIT_CIPH_SM_SC, rtm);
-  Init_cipher(res, ciph, Get_ciph_sfactor(ciph), Sc_degree(ciph));
+  if(Poly_level(&plain->_poly) < Get_ciph_level(ciph)){
+    CIPHER ciph_tmp = Alloc_ciphertext();
+    Copy_ciph(ciph_tmp, ciph);
+    Set_ciph_level(ciph_tmp, Poly_level(&plain->_poly));
+    Init_cipher(res, ciph_tmp, Get_ciph_sfactor(ciph_tmp), Sc_degree(ciph_tmp));
+  }
+  else Init_cipher(res, ciph, Get_ciph_sfactor(ciph), Sc_degree(ciph));
   RTLIB_TM_END(RTM_INIT_CIPH_SM_SC, rtm);
 }
 

--- a/fhe-cmplr/rtlib/ant/ckks/src/cipher.c
+++ b/fhe-cmplr/rtlib/ant/ckks/src/cipher.c
@@ -56,15 +56,9 @@ void Init_ciph_same_scale(CIPHER res, CIPHER ciph1, CIPHER ciph2) {
 
 void Init_ciph_same_scale_plain(CIPHER res, CIPHER ciph, PLAIN plain) {
   RTLIB_TM_START(RTM_INIT_CIPH_SM_SC, rtm);
-  if(Poly_level(Get_plain_poly(plain)) < Get_ciph_level(ciph)){
-    CIPHER ciph_tmp = Alloc_ciphertext();
-    Copy_ciph(ciph_tmp, ciph);
-    Set_ciph_level(ciph_tmp, Poly_level(Get_plain_poly(plain)));
-    Init_cipher(res, ciph_tmp, Get_ciph_sfactor(ciph_tmp), Sc_degree(ciph_tmp));
-  }
-  else{
-    Init_cipher(res, ciph, Get_ciph_sfactor(ciph), Sc_degree(ciph));
-  }
+  Init_cipher(res, ciph, Get_ciph_sfactor(ciph), Sc_degree(ciph));
+  uint32_t plain_level = Poly_level(Get_plain_poly(plain));
+  if (Level(ciph) > plain_level) Set_ciph_level(res, plain_level);
   RTLIB_TM_END(RTM_INIT_CIPH_SM_SC, rtm);
 }
 


### PR DESCRIPTION
Description:
When executing psi.onnx.c, a plaintext data access overflow occurs. This happens because psi.onnx contains a case where a ciphertext is multiplied by two plaintexts at different levels. Currently, the init_ciph_same_scale_plain function in antlib sets the result ciphertext's level directly to the same level as the input ciphertext, causing data access overflow when the ciphertext is multiplied by a plaintext at a lower level.

Solution:
In init_ciph_same_scale_plain, set the result ciphertext's level to the smaller value between the input ciphertext's level and the plaintext's level.